### PR TITLE
CRAN fixes with workaround scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ vignettes/*.pdf
 # Compilation outputs
 *.o
 *.so
+*.a
 
 # OSX
 .DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: osqp
 Title: Quadratic Programming Solver using the 'OSQP' Library
-Version: 0.6.0.6
-Date: 2022-09-28
+Version: 0.6.0.7
+Date: 2022-11-08
 Authors@R: c(
   person("Bartolomeo", "Stellato", role = c("aut", "ctb", "cph"),
          email = "bartolomeo.stellato@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# Version 0.6.0.7
+
+* Fix use of bitwise `&` with boolean operands (file `osqp_interface.cpp`)
+* Fix function declaration without prototype (files
+  `paradiso_loader.h`, `paradiso_interface.c`, `paradiso_loader.c`)
+
 # Version 0.6.0.6
 
 * Change maintainer to Balasubramanian Narasimhan

--- a/inst/26ce409b_fixes/fix_proto.R
+++ b/inst/26ce409b_fixes/fix_proto.R
@@ -1,0 +1,43 @@
+## This script fixes C prototypes to pass CRAN checks
+## Because osqp is slow in accepting my PR, I have to resort to this
+
+## We will prepend a comment line to C source to flag that a fix has been done
+FIXED_FLAG <- "// CRAN PROTOTYPE FIXES DONE"
+cran_prototypes_fixed <- function(lines, signal = FIXED_FLAG) {
+  grepl(FIXED_FLAG, lines[1])
+}
+
+# Fix pardiso_interface.c
+fname <- "osqp_sources/lin_sys/direct/pardiso/pardiso_interface.c"
+lines <- readLines(fname)
+## Skip if already fixed
+if (!cran_prototypes_fixed(lines)) {
+  ## Fix line 35
+  lines[35] <- "c_int mkl_get_max_threads(void);"
+  lines <- c("// CRAN PROTOTYPES FIXED", lines)
+  writeLines(text = lines, con = fname)
+}
+
+# Fix pardiso_loader.h
+fname <- "osqp_sources/lin_sys/direct/pardiso/pardiso_loader.h"
+lines <- readLines(fname)
+## Skip if already fixed
+if (!cran_prototypes_fixed(lines)) {
+  ## Fix line 22
+  lines[22] <- "c_int lh_unload_pardiso(void);"
+  lines <- c("// CRAN PROTOTYPES FIXED", lines)
+  writeLines(text = lines, con = fname)
+}
+
+# Fix pardiso_loader.c
+fname <- "osqp_sources/lin_sys/direct/pardiso/pardiso_loader.c"
+lines <- readLines(fname)
+## Skip if already fixed
+if (!cran_prototypes_fixed(lines)) {
+  ## Fix lines 25, 58, 90
+  lines[25] <- "typedef int (*mkl_get_mt_t)(void);"
+  lines[58] <- "c_int mkl_get_max_threads(void) {"
+  lines[90] <- "c_int lh_unload_pardiso(void) {"
+  lines <- c("// CRAN PROTOTYPES FIXED", lines)
+  writeLines(text = lines, con = fname)
+}

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -29,7 +29,7 @@ $(OSQP_STATIC_LIB):
 		# package is being built in the CRAN servers), then we have
 		# a go at building the static library here.
 		echo "Making prototype fixes to osqp_sources for CRAN"
-		$(R_HOME)/bin/Rscript $(FIXES_SCRIPT)
+		$(R_HOME)/bin$(R_ARCH_BIN)/Rscript $(FIXES_SCRIPT)
 		echo "No cmake?  I will try via osqp/Makefile"
 		cd osqp; \
 		$(MAKE) all CC="$(CC)" \

--- a/src/osqp_solve_interface.cpp
+++ b/src/osqp_solve_interface.cpp
@@ -197,13 +197,13 @@ void osqpUpdate(SEXP workPtr,
   if (q_new.isNotNull()) {
     osqp_update_lin_cost(work, as<NumericVector>(q_new.get()).begin());
   }
-  if (l_new.isNotNull() & u_new.isNull()) {
+  if (l_new.isNotNull() && u_new.isNull()) {
     osqp_update_lower_bound(work, as<NumericVector>(l_new.get()).begin());
   }
-  if (u_new.isNotNull() & l_new.isNull()) {
+  if (u_new.isNotNull() && l_new.isNull()) {
     osqp_update_upper_bound(work, as<NumericVector>(u_new.get()).begin());
   }
-  if (u_new.isNotNull() & l_new.isNotNull()) {
+  if (u_new.isNotNull() && l_new.isNotNull()) {
     osqp_update_bounds(work,
         as<NumericVector>(l_new.get()).begin(),
         as<NumericVector>(u_new.get()).begin());
@@ -227,7 +227,7 @@ void osqpUpdate(SEXP workPtr,
     len_Ax = Ax_.size();
   }
   // Only P
-  if (Px.isNotNull() & Ax.isNull()){
+  if (Px.isNotNull() && Ax.isNull()){
       osqp_update_P(work,
           as<NumericVector>(Px.get()).begin(),
           Px_idx_,
@@ -235,14 +235,14 @@ void osqpUpdate(SEXP workPtr,
   }
 
   // Only A
-  if (Ax.isNotNull() & Px.isNull()){
+  if (Ax.isNotNull() && Px.isNull()){
       osqp_update_A(work, as<NumericVector>(Ax.get()).begin(),
                     Ax_idx_,
                     len_Ax);
   }
 
   // Both A and P
-  if (Px.isNotNull() & Ax.isNotNull()){
+  if (Px.isNotNull() && Ax.isNotNull()){
       osqp_update_P_A(
           work,
           as<NumericVector>(Px.get()).begin(),


### PR DESCRIPTION
@bstellato This version fixes prototype warnings, necessary to keep this package on CRAN.  I've made a [PR](https://github.com/osqp/osqp/pull/487) to` osqp` about this but it looks like it will take a while.  Furthermore, the submodule for the osqp sources here points to an older commit and so I've therefore used some scripts to make the fixes during the build process. See files `inst/*/fix_proto.R` and `Makevars` and `Makevars.win`. 
